### PR TITLE
API surface v1 (FastAPI + CLI)

### DIFF
--- a/core/api/app.py
+++ b/core/api/app.py
@@ -1,0 +1,57 @@
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+from typing import Optional, List, Dict, Any
+
+from core.orchestrator.router import ModelRouter
+from core.orchestrator.policies import Policy
+from core.orchestrator.tools import ToolRegistry
+from core.memory.vector import InMemoryVS
+
+app = FastAPI(title="Sheratan API", version="0.1.0")
+
+# ---- Minimal in-process singletons (stub) ----
+router = ModelRouter(config={"preference": "local_first", "allow_ollama": True, "allow_relay": True, "max_latency_ms": 1500})
+policy = Policy(name="default")
+vs = InMemoryVS()
+reg = ToolRegistry()
+reg.register('echo', lambda p: { 'ok': True, 'payload': p })
+
+class Job(BaseModel):
+    id: str
+    kind: str
+    payload: Dict[str, Any] = Field(default_factory=dict)
+    tools: Optional[List[str]] = None
+    budget: Optional[str] = Field(default="low")
+    latency_ms: Optional[int] = Field(default=1000)
+
+class MemoryQuery(BaseModel):
+    text: str
+    top_k: int = 5
+
+class ToolCall(BaseModel):
+    name: str
+    payload: Dict[str, Any] = Field(default_factory=dict)
+
+@app.get('/health')
+def health():
+    return {"status": "ok", "api": "sheratan", "version": app.version}
+
+@app.post('/router/decide')
+def router_decide(job: Job):
+    if not policy.allow(job.dict()):
+        return {"decision": None, "reason": "policy_reject"}
+    d = router.choose(job.dict())
+    return {"decision": d.model, "reason": d.reason, "policy": d.policy}
+
+@app.post('/memory/add/{doc_id}')
+def memory_add(doc_id: str, q: MemoryQuery):
+    vs.add(doc_id, q.text)
+    return {"ok": True, "doc_id": doc_id}
+
+@app.post('/memory/query')
+def memory_query(q: MemoryQuery):
+    return {"matches": vs.query(q.text, q.top_k)}
+
+@app.post('/tools/run')
+def tools_run(call: ToolCall):
+    return reg.run(call.name, call.payload)

--- a/core/cli.py
+++ b/core/cli.py
@@ -1,0 +1,37 @@
+import argparse, json, sys
+from core.orchestrator.router import ModelRouter
+from core.orchestrator.policies import Policy
+from core.orchestrator.tools import ToolRegistry
+
+reg = ToolRegistry()
+reg.register('echo', lambda p: { 'ok': True, 'payload': p })
+router = ModelRouter(config={"preference": "local_first", "allow_ollama": True, "allow_relay": True, "max_latency_ms": 1500})
+policy = Policy(name="default")
+
+parser = argparse.ArgumentParser(description='Sheratan CLI')
+sub = parser.add_subparsers(dest='cmd')
+
+# decide
+pp = sub.add_parser('decide', help='Router decision for a job JSON')
+pp.add_argument('--job', type=str, help='Inline JSON for job', required=False)
+pp.add_argument('--file', type=str, help='Path to job.json', required=False)
+
+# tool
+tp = sub.add_parser('tool', help='Run a registered tool')
+tp.add_argument('--name', required=True)
+tp.add_argument('--payload', required=False, default='{}')
+
+args = parser.parse_args()
+
+if args.cmd == 'decide':
+    data = json.loads(args.job) if args.job else json.load(open(args.file,'r',encoding='utf-8'))
+    if not policy.allow(data):
+        print(json.dumps({"decision": None, "reason": "policy_reject"}))
+        sys.exit(0)
+    d = router.choose(data)
+    print(json.dumps({"decision": d.model, "reason": d.reason, "policy": d.policy}))
+elif args.cmd == 'tool':
+    payload = json.loads(args.payload)
+    print(json.dumps(reg.run(args.name, payload)))
+else:
+    parser.print_help()

--- a/docs/api/surface.md
+++ b/docs/api/surface.md
@@ -1,0 +1,23 @@
+# Sheratan API Surface (CLI/HTTP)
+
+## HTTP (FastAPI)
+- `GET /health` → status
+- `POST /router/decide` → Model decision for a Job
+- `POST /memory/add/{doc_id}` { text, top_k } → store text
+- `POST /memory/query` { text, top_k } → matches
+- `POST /tools/run` { name, payload } → tool result
+
+Run locally:
+```bash
+# Windows
+scripts\start_api.bat
+# macOS/Linux
+chmod +x scripts/start_api.sh && scripts/start_api.sh
+```
+
+## CLI
+- `python -m core.cli decide --file job.json`
+- `python -m core.cli decide --job '{"id":"1","kind":"task","payload":{},"budget":"low","latency_ms":800}'`
+- `python -m core.cli tool --name echo --payload '{"msg":"hi"}'`
+
+Contracts: see `/interfaces/schemas/*.json`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pydantic

--- a/scripts/start_api.bat
+++ b/scripts/start_api.bat
@@ -1,0 +1,11 @@
+@echo off
+REM Start Sheratan API (FastAPI) on port 8000
+setlocal
+if not exist .venv (
+  echo Creating venv...
+  py -3 -m venv .venv
+)
+call .venv\Scripts\activate.bat
+python -m pip install -U pip
+pip install -r requirements.txt
+uvicorn core.api.app:app --reload --host 0.0.0.0 --port 8000

--- a/scripts/start_api.sh
+++ b/scripts/start_api.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python3 -m venv .venv || true
+source .venv/bin/activate
+pip install -U pip
+pip install -r requirements.txt
+uvicorn core.api.app:app --reload --host 0.0.0.0 --port 8000


### PR DESCRIPTION
This PR adds a minimal HTTP and CLI surface for Sheratan Core.

**Added**
- FastAPI app at `core/api/app.py` with endpoints: /health, /router/decide, /memory/add, /memory/query, /tools/run
- CLI at `core/cli.py` with `decide` and `tool` commands
- Scripts to run API on Windows/Linux
- `requirements.txt` (fastapi, uvicorn, pydantic)
- Docs at `docs/api/surface.md`

**Notes**
- Uses in-process singletons for now; next step: proper DI/config.
- Contracts: `/interfaces/schemas/*`.
