### PR TITLE
CI: sheratan-ci (import smoke + schema load)

### DIFF
--- a/.github/workflows/sheratan_ci.yml
+++ b/.github/workflows/sheratan_ci.yml
@@ -1,0 +1,47 @@
+name: sheratan-ci
+
+on: [push, pull_request]
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install minimal deps
+        run: |
+          python -m pip install -U pip
+          # Only what's needed for import + fastapi app module load
+          pip install fastapi uvicorn pydantic
+      - name: Import smoke test
+        run: |
+          python - << 'PY'
+          import importlib
+          mods = [
+            'core',
+            'core.orchestrator',
+            'core.orchestrator.router',
+            'core.orchestrator.policies',
+            'core.orchestrator.tools',
+            'core.orchestrator.selffix.rewrite_engine',
+            'core.orchestrator.selffix.replay',
+            'core.memory',
+            'core.memory.vector',
+            'core.memory.similarity',
+            'core.api.app',
+          ]
+          for m in mods:
+              importlib.import_module(m)
+          print('SMOKE_OK')
+          PY
+      - name: Validate JSON schemas (loadable)
+        run: |
+          python - << 'PY'
+          import json,glob
+          for p in glob.glob('interfaces/schemas/*.json'):
+              with open(p,'r',encoding='utf-8') as f:
+                  json.load(f)
+          print('SCHEMAS_OK')
+          PY


### PR DESCRIPTION
Adds a minimal CI workflow to catch import errors and broken JSON in schemas.

- Python 3.11
- Installs only fastapi/uvicorn/pydantic
- Smoke-imports key modules (core, orchestrator, memory, api)
- Loads JSON schemas under interfaces/schemas/*.json

Future: add linting and mypy, expand tests once adapters land.