### PR TITLE
Adapters v1: llama-cpp / ollama / web_relay stubs

### DIFF
--- a/core/relay/local_llm.py
+++ b/core/relay/local_llm.py
@@ -1,0 +1,20 @@
+from typing import Dict, Any, Optional
+
+class LlamaCppAdapter:
+    def __init__(self, model_path: str, **kw):
+        self.model_path = model_path
+        self.kw = kw
+        # defer heavy imports; real impl would import llama_cpp
+
+    def generate(self, prompt: str, **opts) -> Dict[str, Any]:
+        # placeholder response
+        return {"model": "llama_cpp", "ok": True, "prompt": prompt, "opts": opts}
+
+class OllamaAdapter:
+    def __init__(self, model: str = 'mistral', host: str = 'http://localhost:11434'):
+        self.model = model
+        self.host = host
+        # real impl: requests/httpx to POST /api/generate
+
+    def generate(self, prompt: str, **opts) -> Dict[str, Any]:
+        return {"model": f"ollama:{self.model}", "ok": True, "prompt": prompt, "opts": opts}

--- a/core/relay/web_relay.py
+++ b/core/relay/web_relay.py
@@ -1,0 +1,12 @@
+from typing import Dict, Any
+import httpx
+
+class WebRelayAdapter:
+    def __init__(self, endpoint: str, api_key: str | None = None, timeout: float = 30.0):
+        self.endpoint = endpoint.rstrip('/')
+        self.api_key = api_key
+        self.timeout = timeout
+
+    def generate(self, prompt: str, **opts) -> Dict[str, Any]:
+        # placeholder: just echo in stub mode
+        return {"model": "web_relay", "ok": True, "prompt": prompt, "opts": opts}

--- a/docs/api/adapters.md
+++ b/docs/api/adapters.md
@@ -1,0 +1,11 @@
+# Adapters (LLM)
+
+Thin adapter layer to connect routers/policies with concrete runtimes.
+
+- `local_llm.py` — placeholders for **llama-cpp** and **Ollama**
+- `web_relay.py` — placeholder for HTTP relay (e.g., GPT-Relay)
+
+Real implementations should be injected via config and handle:
+- timeouts / retries / backoff
+- streaming vs. batch
+- logging & token accounting


### PR DESCRIPTION
Introduces adapter stubs to wire the router to concrete runtimes.

- `core/relay/local_llm.py`: LlamaCppAdapter, OllamaAdapter (placeholders)
- `core/relay/web_relay.py`: WebRelayAdapter (placeholder)
- `docs/api/adapters.md`

Next: configuration and real calls, retries/timeouts, token accounting.