### PR TITLE
LocalHub Panel v1: health + router/decide

### DIFF
--- a/ui/localhub_stub/core_panel.html
+++ b/ui/localhub_stub/core_panel.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Sheratan LocalHub • Core Panel</title>
+<style>body{background:#0b0b0b;color:#e8e8e8;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;margin:0}a{color:#00C3D4}header{padding:16px 20px;border-bottom:1px solid #1f1f1f;display:flex;gap:16px;align-items:center}main{padding:20px}h1,h2{color:#00A3D9}input,button,select,textarea{background:#131313;color:#e8e8e8;border:1px solid #272727;border-radius:10px;padding:8px}section{border:1px solid #1f1f1f;border-radius:16px;padding:16px;margin:16px 0}</style>
+<header>
+  <strong>LocalHub</strong> • <em>Core Panel</em>
+  <nav style="margin-left:auto"><a href="../index.html">Home</a></nav>
+</header>
+<main>
+  <h1>Core Control</h1>
+  <section>
+    <h2>Health</h2>
+    <button id="btnHealth">Check /health</button>
+    <pre id="outHealth"></pre>
+  </section>
+  <section>
+    <h2>Router Decide</h2>
+    <textarea id="job" rows="6">{
+  "id": "demo-1",
+  "kind": "task",
+  "payload": {},
+  "budget": "low",
+  "latency_ms": 800
+}</textarea>
+    <div style="margin-top:8px"><button id="btnDecide">POST /router/decide</button></div>
+    <pre id="outDecide"></pre>
+  </section>
+</main>
+<script>
+const API = (localStorage.getItem('sheratan_api')||'http://localhost:8000').replace(//$/,'');
+async function j(url,opts){const r=await fetch(url,{headers:{'content-type':'application/json'},...opts});return await r.json()}
+btnHealth.onclick=async()=>{ outHealth.textContent='…'; try{ outHealth.textContent=JSON.stringify(await j(API+'/health'),null,2) }catch(e){ outHealth.textContent=String(e) } }
+btnDecide.onclick=async()=>{ outDecide.textContent='…'; try{ outDecide.textContent=JSON.stringify(await j(API+'/router/decide',{method:'POST',body:job.value}),null,2)}catch(e){ outDecide.textContent=String(e)} }
+</script>


### PR DESCRIPTION
Adds a Core Panel page for LocalHub that can talk to the API locally.

- `ui/localhub_stub/core_panel.html` with /health and /router/decide testers
- Stores API base in localStorage key `sheratan_api` (default http://localhost:8000)

Next: status indicators, artifacts list, and inline MD viewer.