### PR TITLE
Agents: Coding Agent skeleton

### DIFF
--- a/core/agents/coding_agent/agent.py
+++ b/core/agents/coding_agent/agent.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from typing import Dict, Any, List
+
+@dataclass
+class CodingPlan:
+    files: List[Dict[str, Any]]  # [{path, task, deps?}]
+
+class CodingAgent:
+    def __init__(self, router):
+        self.router = router
+
+    def analyze(self, prompt: str) -> CodingPlan:
+        # stub: one file
+        return CodingPlan(files=[{"path": "demo/hello.py", "task": "print('hello')"}])
+
+    def generate(self, plan: CodingPlan) -> Dict[str, str]:
+        # stub: produce content map
+        return {f["path"]: f"# generated
+{f['task']}" for f in plan.files}
+
+    def review(self, contents: Dict[str, str]) -> Dict[str, Any]:
+        # stub review
+        return {"ok": True, "notes": []}

--- a/docs/agents/coding_agent.md
+++ b/docs/agents/coding_agent.md
@@ -1,0 +1,13 @@
+# Coding Agent (skeleton)
+
+Minimal thinker→generator→review loop.
+
+API sketch:
+```python
+agent = CodingAgent(router)
+plan = agent.analyze("make a hello file")
+files = agent.generate(plan)
+report = agent.review(files)
+```
+
+Next: connect to adapters, add replay/reflexion hooks.


### PR DESCRIPTION
Adds a minimal coding agent with analyze→generate→review cycle and docs.

- `core/agents/coding_agent/agent.py`
- `docs/agents/coding_agent.md`

Next: connect to adapters, replay/reflection, and file apply.