### PR TITLE
Agents API v1.1: POST /agents/coding + registry skeleton

### DIFF
--- a/core/agents/registry.py
+++ b/core/agents/registry.py
@@ -1,0 +1,11 @@
+from typing import Dict, Type
+
+# Skeleton registry for future agent classes
+
+_REGISTRY: Dict[str, type] = {}
+
+def register(name: str, cls: type):
+    _REGISTRY[name] = cls
+
+def get(name: str) -> type | None:
+    return _REGISTRY.get(name)

--- a/core/api/agents.py
+++ b/core/api/agents.py
@@ -1,0 +1,38 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+from typing import Dict, Any
+
+from core.agents.coding_agent.agent import CodingAgent
+from core.orchestrator.router import ModelRouter
+from core.orchestrator.policies import Policy
+
+router = APIRouter(prefix='/agents', tags=['agents'])
+
+# In a future step these would be injected
+_router = ModelRouter(config={
+    'preference': 'local_first',
+    'allow_ollama': True,
+    'allow_relay': True,
+    'max_latency_ms': 1500,
+})
+_policy = Policy(name='default')
+
+class CodingRequest(BaseModel):
+    prompt: str
+
+@router.post('/coding')
+def run_coding_agent(req: CodingRequest) -> Dict[str, Any]:
+    # basic policy guard (could inspect prompt length, budget, etc.)
+    if not _policy.allow({'budget': 'low', 'latency_ms': 800}):
+        return {'ok': False, 'reason': 'policy_reject'}
+
+    agent = CodingAgent(_router)
+    plan = agent.analyze(req.prompt)
+    files = agent.generate(plan)
+    review = agent.review(files)
+    return {
+        'ok': True,
+        'plan': plan.__dict__,
+        'files': files,
+        'review': review,
+    }

--- a/core/api/app.py
+++ b/core/api/app.py
@@ -6,6 +6,7 @@ from core.orchestrator.router import ModelRouter
 from core.orchestrator.policies import Policy
 from core.orchestrator.tools import ToolRegistry
 from core.memory.vector import InMemoryVS
+from .agents import router as agents_router
 
 app = FastAPI(title="Sheratan API", version="0.1.0")
 
@@ -15,6 +16,9 @@ policy = Policy(name="default")
 vs = InMemoryVS()
 reg = ToolRegistry()
 reg.register('echo', lambda p: { 'ok': True, 'payload': p })
+
+# Mount agents subrouter
+app.include_router(agents_router)
 
 class Job(BaseModel):
     id: str

--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -1,0 +1,20 @@
+# Agents API
+
+### POST /agents/coding
+Request:
+```json
+{ "prompt": "make a hello file" }
+```
+Response (stub):
+```json
+{
+  "ok": true,
+  "plan": { "files": [{ "path": "demo/hello.py", "task": "print('hello')" }] },
+  "files": { "demo/hello.py": "# generated\nprint('hello')" },
+  "review": { "ok": true, "notes": [] }
+}
+```
+
+### Notes
+- This is a minimal skeleton to be extended with adapters, replay/reflection, and persistence.
+- Later, `core.agents.registry` can be used to resolve agent classes by name (e.g. `coding`, `trader`, `research`).


### PR DESCRIPTION
Adds a minimal Agents API and a skeleton registry.

**API**
- `POST /agents/coding` – runs CodingAgent (analyze→generate→review) and returns `{ plan, files, review }`.
- Mounted via `app.include_router(agents_router)` in `core/api/app.py`.

**Registry**
- `core/agents/registry.py` – simple `register()/get()` for future agent classes (e.g., trader, research).

**Docs**
- `docs/api/agents.md` with request/response examples.

Next: wire adapters into CodingAgent, add replay/reflection hooks and persistence.